### PR TITLE
Add sign in/out link at bottom of app page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ playwright-report/
 test-results/
 !tests/test-results/.gitkeep
 _site/
+.vercel

--- a/app.html
+++ b/app.html
@@ -423,6 +423,10 @@
         <div style="text-align: center; margin-top: 12px; font-size: 14px; color: rgba(255, 255, 255, 0.5);" id="userInfo"></div>
 
         <button class="btn-secondary" id="testBtn">Start</button>
+
+        <div style="text-align: center; margin-top: 20px;">
+            <a href="#" id="authLink" style="font-size: 16px; color: rgba(255, 149, 0, 0.8); text-decoration: none; cursor: pointer;">Sign in</a>
+        </div>
     </div>
 
     <div class="alarm-window" id="alarmWindow">
@@ -566,6 +570,7 @@
             const logoutBtn = document.getElementById('logoutBtn');
             const loginBtn = document.getElementById('loginBtn');
             const userInfo = document.getElementById('userInfo');
+            const authLink = document.getElementById('authLink');
 
             if (currentUser) {
                 loginBtn.style.display = 'none';
@@ -578,12 +583,28 @@
                 const roleEmoji = currentUser.role === 'admin' ? '👑' : currentUser.role === 'premium' ? '⭐' : '🆓';
                 userInfo.textContent = `${roleEmoji} Logged in as ${currentUser.email} (${currentUser.role})`;
                 userInfo.style.display = 'block';
+
+                // Update bottom auth link for signed-in users
+                authLink.textContent = `Sign out ${currentUser.email}`;
+                authLink.onclick = (e) => {
+                    e.preventDefault();
+                    if (typeof logout !== 'undefined') {
+                        logout();
+                    }
+                };
             } else {
                 loginBtn.style.display = 'block';
                 logoutBtn.style.display = 'none';
                 adminBtn.style.display = 'none';
                 userInfo.textContent = 'Using local storage (not synced)';
                 userInfo.style.display = 'block';
+
+                // Update bottom auth link for signed-out users
+                authLink.textContent = 'Sign in';
+                authLink.onclick = (e) => {
+                    e.preventDefault();
+                    window.location.href = '/auth.html';
+                };
             }
         }
 


### PR DESCRIPTION
## Summary
- Added a sign in/out link at the bottom of the app page that changes based on authentication state
- For signed-out users: displays "Sign in" and navigates to /auth.html
- For signed-in users: displays "Sign out {email}" and triggers logout
- Updated `updateAuthUI()` function to manage the link dynamically
- Also added `.vercel` to .gitignore from Vercel CLI usage

## UI Changes
The link is styled in orange to match the app's accent color and positioned at the bottom of the main container with proper spacing.

## Test plan
- [ ] Test as signed-out user: click "Sign in" link → should navigate to /auth.html
- [ ] Test as signed-in user: verify link shows "Sign out {email}"
- [ ] Test as signed-in user: click link → should log out and redirect to /auth.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authentication link at the bottom of the page displaying current sign-in status
  * Signed-in users can click to sign out (with email displayed)
  * New users can click to navigate to the sign-in page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->